### PR TITLE
[Fix] 길이, 정렬, 패딩, 스크롤바, 아이콘 수정(#40)

### DIFF
--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/ViewControllers/MainTabBarController.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/ViewControllers/MainTabBarController.swift
@@ -30,24 +30,25 @@ class MainTabBarController: UITabBarController {
         
         gridVC.do {
             $0.view.backgroundColor = .white
-            $0.tabBarItem = UITabBarItem(title: "", image: UIImage(named: "btn_menu_ios"), tag: 1)
+            $0.tabBarItem = UITabBarItem(title: "", image: UIImage(named: "btn_menu_ios")?.withRenderingMode(.alwaysOriginal), tag: 1)
         }
         
         bellVC.do {
             $0.view.backgroundColor = .white
-            $0.tabBarItem = UITabBarItem(title: "", image: UIImage(named: "btn_notification_ios"), tag: 2)
+            $0.tabBarItem = UITabBarItem(title: "", image: UIImage(named: "btn_notification_ios")?.withRenderingMode(.alwaysOriginal), tag: 2)
         }
         
         dotsVC.do {
             $0.view.backgroundColor = .white
-            $0.tabBarItem = UITabBarItem(title: "", image: UIImage(named: "btn_mypage_ios"), tag: 3)
+            $0.tabBarItem = UITabBarItem(title: "", image: UIImage(named: "btn_mypage_ios")?.withRenderingMode(.alwaysOriginal), tag: 3)
         }
         
         tabBar.do {
             $0.barTintColor = UIColor(resource: .white)
-            $0.isTranslucent = true
+            $0.isTranslucent = false
             $0.tintColor = UIColor(named: "black2") // Color for selected item
-            $0.unselectedItemTintColor = UIColor(named: "gray6") // Color for unselected items
+//            $0.unselectedItemTintColor = UIColor(named: "gray6")
+            $0.backgroundColor = .white
         }
     }
     

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/ViewControllers/MainViewController.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/ViewControllers/MainViewController.swift
@@ -69,50 +69,57 @@ class MainViewController: UIViewController {
         headerView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(0)
             $0.centerX.equalToSuperview()
-            $0.width.equalToSuperview()
+            $0.width.equalTo(380)
             $0.height.equalTo(118)
 
         }
         
         messageBoxView.snp.makeConstraints {
             $0.top.equalTo(contentView.snp.top).offset(60)
-            $0.horizontalEdges.equalToSuperview().inset(17)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(341)
             $0.height.equalTo(99)
         }
         
         mainAccountView.snp.makeConstraints {
             $0.top.equalTo(messageBoxView.snp.bottom).offset(9)
-            $0.horizontalEdges.equalToSuperview().inset(17)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(341)
             $0.height.equalTo(177)
         }
         
         secondAccountView.snp.makeConstraints {
             $0.top.equalTo(mainAccountView.snp.bottom).offset(9)
-            $0.horizontalEdges.equalToSuperview().inset(17)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(341)
             $0.height.equalTo(99)
         }
         
         thirdAccountView.snp.makeConstraints {
             $0.top.equalTo(secondAccountView.snp.bottom).offset(9)
-            $0.horizontalEdges.equalToSuperview().inset(17)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(341)
             $0.height.equalTo(140)
         }
         
         savingsView.snp.makeConstraints {
             $0.top.equalTo(thirdAccountView.snp.bottom).offset(9)
-            $0.horizontalEdges.equalToSuperview().inset(17)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(341)
             $0.height.equalTo(85)
         }
         
         meetingAccountView.snp.makeConstraints {
             $0.top.equalTo(savingsView.snp.bottom).offset(9)
-            $0.horizontalEdges.equalToSuperview().inset(17)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(341)
             $0.height.equalTo(62)
         }
         
         addButtonView.snp.makeConstraints {
             $0.top.equalTo(meetingAccountView.snp.bottom).offset(9)
-            $0.horizontalEdges.equalToSuperview().inset(17)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(341)
             $0.height.equalTo(58)
         }
         
@@ -124,7 +131,7 @@ class MainViewController: UIViewController {
         
         tipsViewController.view.snp.makeConstraints {
             $0.top.equalTo(simpleBarView.snp.bottom).offset(4)
-            $0.horizontalEdges.equalToSuperview().inset(17)
+            $0.horizontalEdges.equalToSuperview().inset(14)
             $0.height.equalTo(150)
             $0.width.equalToSuperview()
         }
@@ -132,7 +139,8 @@ class MainViewController: UIViewController {
         adView.snp.makeConstraints {
             $0.top.equalTo(simpleBarView.snp.bottom).offset(170)
             $0.centerX.equalToSuperview()
-            $0.horizontalEdges.equalToSuperview().inset(17)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(341)
             $0.height.equalTo(82)
             $0.bottom.equalToSuperview().offset(-20)
         }
@@ -147,10 +155,6 @@ extension MainViewController: UIScrollViewDelegate {
         let offsetY = scrollView.contentOffset.y
             headerViewTopConstraint?.update(offset: max(0, -offsetY))
         
-//        let offsetY = scrollView.contentOffset.y
-//        headerView.snp.updateConstraints {
-//            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(max(0, -offsetY))
-//        }
     }
 }
 

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/ViewControllers/TipsViewController.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/ViewControllers/TipsViewController.swift
@@ -43,6 +43,8 @@ class TipsViewController: UIViewController {
         collectionView.delegate = self
         collectionView.dataSource = self
         collectionView.register(TipsCollectionViewCell.self, forCellWithReuseIdentifier: TipsCollectionViewCell.identifier)
+        
+        collectionView.showsHorizontalScrollIndicator = false
     }
 }
 

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/Views/AddButtonView.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/Views/AddButtonView.swift
@@ -39,10 +39,8 @@ class AddButtonView: UIView {
     
     private func setLayout() {
         leadingImageView.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(158)
+            make.left.equalToSuperview().offset(158)
             make.top.equalToSuperview().offset(17)
-            make.width.equalTo(24)
-            make.height.equalTo(24)
         }
         
 

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/Views/MainAccountView.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/Views/MainAccountView.swift
@@ -37,7 +37,7 @@ class MainAccountView: UIView {
     private func setStyle() {
         bankImageView.do {
             $0.image = UIImage(named: "icn_bankimg1_ios")
-            $0.contentMode = .scaleAspectFit
+//            $0.contentMode = .scaleAspectFit
         }
         
         titleLabel.do {
@@ -50,7 +50,7 @@ class MainAccountView: UIView {
         
         starImageView.do {
             $0.image = UIImage(named: "icn_star_ios")
-            $0.contentMode = .scaleAspectFit
+//            $0.contentMode = .scaleAspectFit
         }
         
         balanceLabel.do {
@@ -61,7 +61,7 @@ class MainAccountView: UIView {
         
         moreButton.do {
             $0.image = UIImage(named: "btn_more_ios")
-            $0.contentMode = .scaleAspectFit
+//            $0.contentMode = .scaleAspectFit
         }
         
         cardButton.do {
@@ -116,7 +116,7 @@ class MainAccountView: UIView {
         bankImageView.snp.makeConstraints { make in
             make.leading.equalToSuperview().offset(20)
             make.top.equalToSuperview().offset(34)
-            make.width.height.equalTo(40)
+            make.width.height.equalTo(30)
         }
         
         titleLabel.snp.makeConstraints { make in
@@ -125,14 +125,14 @@ class MainAccountView: UIView {
         }
         
         starImageView.snp.makeConstraints { make in
-            make.leading.equalTo(titleLabel.snp.trailing).offset(4)
+            make.leading.equalTo(titleLabel.snp.trailing).offset(0)
             make.top.equalToSuperview().offset(26)
             make.width.height.equalTo(20)
         }
         
         balanceLabel.snp.makeConstraints { make in
             make.leading.equalTo(titleLabel.snp.leading)
-            make.top.equalTo(titleLabel.snp.bottom).offset(5)
+            make.top.equalTo(titleLabel.snp.bottom).offset(6)
         }
         
         moreButton.snp.makeConstraints { make in
@@ -142,29 +142,28 @@ class MainAccountView: UIView {
         }
         
         cardButton.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(229)
+            make.leading.equalToSuperview().offset(216)
             make.top.equalToSuperview().offset(70)
             make.height.equalTo(31)
             make.width.equalTo(48)
         }
         
         transferButton.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(284)
+            make.leading.equalTo(cardButton.snp.trailing).offset(7)
             make.top.equalToSuperview().offset(70)
             make.height.equalTo(31)
             make.width.equalTo(48)
         }
         
         separatorLine.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(22)
             make.top.equalTo(balanceLabel.snp.bottom).offset(52)
-            make.width.equalTo(297)
+            make.horizontalEdges.equalToSuperview().inset(22)
             make.height.equalTo(1)
         }
         
         safeBoxLabel.snp.makeConstraints { make in
             make.leading.equalToSuperview().offset(21)
-            make.bottom.equalToSuperview().inset(21)
+            make.bottom.equalToSuperview().inset(22.5)
         }
         
         amountLabel.snp.makeConstraints { make in

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/Views/MeetingAccountView.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/Views/MeetingAccountView.swift
@@ -54,10 +54,8 @@ class MeetingAccountView: UIView {
         }
         
         leadingImageView.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(293)
+            make.trailing.equalToSuperview().offset(-18.5)
             make.top.equalToSuperview().offset(19.5)
-            make.width.equalTo(24)
-            make.height.equalTo(24)
         }
     }
 }

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/Views/MessageBoxView.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/Views/MessageBoxView.swift
@@ -38,7 +38,7 @@ class MessageBoxView: UIView {
         // Set the styles for messageLabel using Then
         messageLabel.do {
             $0.textColor = UIColor(resource: .white)
-            $0.attributedText = UILabel.attributedText(for: .subTitle2, withText: "김미정님의 신용점수는\n 대출 승인 가능성이 높아요")
+            $0.attributedText = UILabel.attributedText(for: .subTitle2, withText: "김미정님의 신용점수는\n대출 승인 가능성이 높아요")
             $0.numberOfLines = 0  // 여러 줄 표시 가능하도록 설정
         }
 

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/Views/SavingsView.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/Views/SavingsView.swift
@@ -57,14 +57,14 @@ class SavingsView: UIView {
     // Set up constraints using SnapKit
     private func setLayout() {
         bagImageView.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(24)
-            make.top.equalToSuperview().offset(18)
+            make.leading.equalToSuperview().offset(26)
+            make.top.equalToSuperview().offset(31)
             make.width.equalTo(30)
             make.height.equalTo(27)
         }
         
         messageLabel.snp.makeConstraints { make in
-            make.leading.equalTo(bagImageView.snp.trailing).offset(6)
+            make.leading.equalTo(bagImageView.snp.trailing).offset(13)
             make.top.equalToSuperview().offset(23)
         }
         

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/Views/SecondAccountView.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/Views/SecondAccountView.swift
@@ -60,7 +60,7 @@ class SecondAccountView: UIView {
         bankImageView.snp.makeConstraints { make in
             make.leading.equalToSuperview().offset(20)
             make.top.equalToSuperview().offset(34)
-            make.width.height.equalTo(40)
+            make.width.height.equalTo(30)
         }
         
         titleLabel.snp.makeConstraints { make in
@@ -70,7 +70,7 @@ class SecondAccountView: UIView {
         
         balanceLabel.snp.makeConstraints { make in
             make.leading.equalTo(titleLabel.snp.leading)
-            make.top.equalTo(titleLabel.snp.bottom).offset(5)
+            make.top.equalTo(titleLabel.snp.bottom).offset(6)
         }
         
         moreButton.snp.makeConstraints { make in

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/Views/ThirdAccountView.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/Views/ThirdAccountView.swift
@@ -106,18 +106,18 @@ class ThirdAccountView: UIView {
     private func setLayout() {
         bankImageView.snp.makeConstraints { make in
             make.leading.equalToSuperview().offset(20)
-            make.top.equalToSuperview().offset(34)
-            make.width.height.equalTo(40)
+            make.top.equalToSuperview().offset(35)
+            make.width.height.equalTo(30)
         }
         
         titleLabel.snp.makeConstraints { make in
             make.leading.equalTo(bankImageView.snp.trailing).offset(8)
-            make.top.equalToSuperview().offset(29)
+            make.top.equalToSuperview().offset(30)
         }
         
         balanceLabel.snp.makeConstraints { make in
             make.leading.equalTo(titleLabel.snp.leading)
-            make.top.equalTo(titleLabel.snp.bottom).offset(5)
+            make.top.equalTo(titleLabel.snp.bottom).offset(6)
         }
         
         emerFund.snp.makeConstraints { make in
@@ -146,7 +146,7 @@ class ThirdAccountView: UIView {
         }
         
         transferButton.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(284)
+            make.leading.equalToSuperview().offset(271)
             make.top.equalToSuperview().offset(90)
             make.height.equalTo(31)
             make.width.equalTo(48)


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- fix/#40

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 모든 파일의 레이아웃 확인 및 수정
- 컬뷰의 가로 스크롤 기능 없애기
- 스크롤해도 하단 탭 바 색 바뀌지 않도록 수정
- 하단 탭 바의 이미지 알림 빨간색으로 변경

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰15Pro|<img src="https://github.com/NOW-SOPT-APP2-KAKAOBANK/KAKAOBANK-iOS/assets/96602351/41fd6dca-1718-4673-878a-709020dd5d2e" width="300px">|


## 📟 관련 이슈
- Resolved: #40
