### PR TITLE
[FIX] 계좌 내역 뷰에 하단 탭바 추가 (#45)

### DIFF
--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/ViewControllers/BankAccountViewController.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/ViewControllers/BankAccountViewController.swift
@@ -23,6 +23,8 @@ final class BankAccountViewController: UIViewController {
     private let stickyHeaderView = StickyHeaderView()
     private let headerView = StickyHeaderView()
     
+    private let backgroundView = UIView()
+    
     
 
     
@@ -60,7 +62,7 @@ final class BankAccountViewController: UIViewController {
 private extension BankAccountViewController {
     
     func setHierarchy() {
-        self.view.addSubviews(scrollView,bankAccountNaviBar,headerView)
+        self.view.addSubviews(backgroundView,scrollView,bankAccountNaviBar, headerView)
         
         scrollView.addSubview(contentView)
         self.contentView.addSubviews(bankAccountUpperView, bankAccountTableView, stickyHeaderView)
@@ -91,7 +93,6 @@ private extension BankAccountViewController {
             $0.height.equalTo(229)
         }
         
-        
         //스티키 헤더 뷰
         stickyHeaderView.snp.makeConstraints {
             $0.top.equalTo(bankAccountUpperView.snp.bottom)
@@ -104,12 +105,21 @@ private extension BankAccountViewController {
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(163)
         }
+        
+        backgroundView.snp.makeConstraints {
+            $0.bottom.equalToSuperview()
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(300)
+        }
+        
     }
     
     func setStyle() {
         self.view.backgroundColor = UIColor(resource: .main)
         self.navigationController?.isNavigationBarHidden = true
         bankAccountTableView.isScrollEnabled = true
+     
+        backgroundView.backgroundColor = .white
         
         stickyHeaderView.do {
             $0.backgroundColor = .white
@@ -124,6 +134,8 @@ private extension BankAccountViewController {
             $0.backgroundColor = .white
             $0.isHidden = true
         }
+        
+        
     }
     
     func setDelegate() {

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/ViewControllers/BankAccountViewController.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/ViewControllers/BankAccountViewController.swift
@@ -195,6 +195,7 @@ extension BankAccountViewController: BankAccountUpperViewDelegate {
     
     func pushToTransferVC() {
         let transferVC = TransferViewController()
+        transferVC.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(transferVC, animated: true)
     }
 }

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/ViewControllers/MainTabBarController.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/ViewControllers/MainTabBarController.swift
@@ -53,7 +53,9 @@ class MainTabBarController: UITabBarController {
     }
     
     private func setHierarchy() {
-        let viewControllers = [profileVC, gridVC, bellVC, dotsVC]
+        let profileNavVC = UINavigationController(rootViewController: profileVC)
+        
+        let viewControllers = [profileNavVC, gridVC, bellVC, dotsVC]
         self.setViewControllers(viewControllers, animated: false)
         
         if let items = tabBar.items {

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/ViewControllers/MainViewController.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/ViewControllers/MainViewController.swift
@@ -178,7 +178,7 @@ extension MainViewController: MainAccountViewDelegate {
 }
 
 
-// 프리뷰를 위한 코드
+// 프리뷰를 위한 코드 
 struct MainViewController_Previews: PreviewProvider {
     static var previews: some View {
         MainViewControllerRepresentable()


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- fix/#45

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 계좌 내역 뷰에 하단 탭바 추가
- 스크롤시 하단 영역에 노란 배경 안보이도록 수정


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰15Pro|![Simulator Screen Recording - iPhone 15 Pro - 2024-05-21 at 10 43 08](https://github.com/NOW-SOPT-APP2-KAKAOBANK/KAKAOBANK-iOS/assets/105372558/446fe5a9-114d-464a-a19f-edfc1621a9ef)|



## 📟 관련 이슈
- Resolved: #45 
