### PR TITLE
[FEAT] 즐겨찾기 등록 서버 통신 (#52)

### DIFF
--- a/KAKAOBANK-iOS/KAKAOBANK-iOS.xcodeproj/project.pbxproj
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		CA0C2CE32BFC86960026C6C7 /* TransferTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C2CE22BFC86960026C6C7 /* TransferTargetType.swift */; };
 		CA0C2CE52BFC88B90026C6C7 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C2CE42BFC88B90026C6C7 /* NetworkService.swift */; };
 		CA0C2CE82BFC8C9E0026C6C7 /* GetRecentTransferResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C2CE72BFC8C9E0026C6C7 /* GetRecentTransferResponseDTO.swift */; };
+		CA0C2CEC2BFCE8550026C6C7 /* BookmarkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C2CEB2BFCE8550026C6C7 /* BookmarkService.swift */; };
+		CA0C2CF22BFCE9CB0026C6C7 /* BookmarkTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C2CF12BFCE9CB0026C6C7 /* BookmarkTargetType.swift */; };
 		CA22B3EF2BF136420013B7AB /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = CA22B3EE2BF136420013B7AB /* Pretendard-Bold.otf */; };
 		CA22B3F12BF1364C0013B7AB /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = CA22B3F02BF1364C0013B7AB /* Pretendard-Medium.otf */; };
 		CA22B3F32BF136580013B7AB /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = CA22B3F22BF136580013B7AB /* Pretendard-Regular.otf */; };
@@ -115,6 +117,8 @@
 		CA0C2CE22BFC86960026C6C7 /* TransferTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferTargetType.swift; sourceTree = "<group>"; };
 		CA0C2CE42BFC88B90026C6C7 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		CA0C2CE72BFC8C9E0026C6C7 /* GetRecentTransferResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetRecentTransferResponseDTO.swift; sourceTree = "<group>"; };
+		CA0C2CEB2BFCE8550026C6C7 /* BookmarkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkService.swift; sourceTree = "<group>"; };
+		CA0C2CF12BFCE9CB0026C6C7 /* BookmarkTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkTargetType.swift; sourceTree = "<group>"; };
 		CA22B3EE2BF136420013B7AB /* Pretendard-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.otf"; sourceTree = "<group>"; };
 		CA22B3F02BF1364C0013B7AB /* Pretendard-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Medium.otf"; sourceTree = "<group>"; };
 		CA22B3F22BF136580013B7AB /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
@@ -297,6 +301,7 @@
 		CA0C2CD22BFC7C7B0026C6C7 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				CA0C2CE92BFCE8400026C6C7 /* Bookmark */,
 				CA0C2CDF2BFC85BA0026C6C7 /* Transfer */,
 				CA0C2CD32BFC7C810026C6C7 /* Base */,
 			);
@@ -332,6 +337,15 @@
 				CA0C2CE72BFC8C9E0026C6C7 /* GetRecentTransferResponseDTO.swift */,
 			);
 			path = DTO;
+			sourceTree = "<group>";
+		};
+		CA0C2CE92BFCE8400026C6C7 /* Bookmark */ = {
+			isa = PBXGroup;
+			children = (
+				CA0C2CEB2BFCE8550026C6C7 /* BookmarkService.swift */,
+				CA0C2CF12BFCE9CB0026C6C7 /* BookmarkTargetType.swift */,
+			);
+			path = Bookmark;
 			sourceTree = "<group>";
 		};
 		CA22B3E02BF1328E0013B7AB /* Global */ = {
@@ -605,10 +619,12 @@
 				CA05B3B42BF34B9800DA77E1 /* SelectBankHeaderView.swift in Sources */,
 				CA05B3B62BF3E6FF00DA77E1 /* SegmentView.swift in Sources */,
 				CA22B3F92BF13C380013B7AB /* UILabel+.swift in Sources */,
+				CA0C2CF22BFCE9CB0026C6C7 /* BookmarkTargetType.swift in Sources */,
 				CA0C2CE12BFC86280026C6C7 /* TransferService.swift in Sources */,
 				CA05B3A32BF27AF300DA77E1 /* MyAccountCell.swift in Sources */,
 				CA0C2CE82BFC8C9E0026C6C7 /* GetRecentTransferResponseDTO.swift in Sources */,
 				0DB63ACA2BF7565D007AA8C8 /* BankAccountUpperView.swift in Sources */,
+				CA0C2CEC2BFCE8550026C6C7 /* BookmarkService.swift in Sources */,
 				CA9982BC2BF5282600EC1F56 /* BottomSheetView.swift in Sources */,
 				CA05B3AA2BF2923700DA77E1 /* RecentTransferCell.swift in Sources */,
 				CA0C2CE32BFC86960026C6C7 /* TransferTargetType.swift in Sources */,

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS.xcodeproj/project.pbxproj
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		CA0C2CE82BFC8C9E0026C6C7 /* GetRecentTransferResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C2CE72BFC8C9E0026C6C7 /* GetRecentTransferResponseDTO.swift */; };
 		CA0C2CEC2BFCE8550026C6C7 /* BookmarkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C2CEB2BFCE8550026C6C7 /* BookmarkService.swift */; };
 		CA0C2CF22BFCE9CB0026C6C7 /* BookmarkTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C2CF12BFCE9CB0026C6C7 /* BookmarkTargetType.swift */; };
+		CA0C2CF52BFCFDD20026C6C7 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = CA0C2CF42BFCFDD20026C6C7 /* Kingfisher */; };
 		CA22B3EF2BF136420013B7AB /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = CA22B3EE2BF136420013B7AB /* Pretendard-Bold.otf */; };
 		CA22B3F12BF1364C0013B7AB /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = CA22B3F02BF1364C0013B7AB /* Pretendard-Medium.otf */; };
 		CA22B3F32BF136580013B7AB /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = CA22B3F22BF136580013B7AB /* Pretendard-Regular.otf */; };
@@ -156,6 +157,7 @@
 				CAD3988D2BECEEE100B57329 /* Then in Frameworks */,
 				CAD398902BECEF1A00B57329 /* Moya in Frameworks */,
 				CAD3988A2BECEEB900B57329 /* SnapKit-Dynamic in Frameworks */,
+				CA0C2CF52BFCFDD20026C6C7 /* Kingfisher in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -528,6 +530,7 @@
 				CAD398892BECEEB900B57329 /* SnapKit-Dynamic */,
 				CAD3988C2BECEEE100B57329 /* Then */,
 				CAD3988F2BECEF1A00B57329 /* Moya */,
+				CA0C2CF42BFCFDD20026C6C7 /* Kingfisher */,
 			);
 			productName = "KAKAOBANK-iOS";
 			productReference = CAD3986F2BECED3F00B57329 /* KAKAOBANK-iOS.app */;
@@ -561,6 +564,7 @@
 				CAD398862BECEEB900B57329 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				CAD3988B2BECEEE100B57329 /* XCRemoteSwiftPackageReference "Then" */,
 				CAD3988E2BECEF1A00B57329 /* XCRemoteSwiftPackageReference "Moya" */,
+				CA0C2CF32BFCFDD20026C6C7 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 			);
 			productRefGroup = CAD398702BECED3F00B57329 /* Products */;
 			projectDirPath = "";
@@ -878,6 +882,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		CA0C2CF32BFCFDD20026C6C7 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/onevcat/Kingfisher.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 7.11.0;
+			};
+		};
 		CAD398862BECEEB900B57329 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SnapKit/SnapKit";
@@ -905,6 +917,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		CA0C2CF42BFCFDD20026C6C7 /* Kingfisher */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CA0C2CF32BFCFDD20026C6C7 /* XCRemoteSwiftPackageReference "Kingfisher" */;
+			productName = Kingfisher;
+		};
 		CAD398872BECEEB900B57329 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = CAD398862BECEEB900B57329 /* XCRemoteSwiftPackageReference "SnapKit" */;

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "6cff3f6b7c264d53af1d216bc25530a1cda9d3e1d07ca6b23c15aa5524431c46",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -7,6 +8,15 @@
       "state" : {
         "revision" : "f455c2975872ccd2d9c81594c658af65716e9b9a",
         "version" : "5.9.1"
+      }
+    },
+    {
+      "identity" : "kingfisher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Kingfisher.git",
+      "state" : {
+        "revision" : "5b92f029fab2cce44386d28588098b5be0824ef5",
+        "version" : "7.11.0"
       }
     },
     {
@@ -55,5 +65,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/Base/BaseResponseDTO.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/Base/BaseResponseDTO.swift
@@ -1,0 +1,14 @@
+//
+//  BaseResponseDTO.swift
+//  KAKAOBANK-iOS
+//
+//  Created by 윤희슬 on 5/21/24.
+//
+
+import Foundation
+
+struct BaseResponseDTO: Codable {
+    let status: Int
+    let message: String
+    let data: Data?
+}

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/Base/NetworkService.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/Base/NetworkService.swift
@@ -14,4 +14,6 @@ final class NetworkService {
     private init() {}
     
     let transferService: TransferService = TransferService()
+    
+    let bookmarkService: BookmarkService = BookmarkService()
 }

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/Bookmark/BookmarkService.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/Bookmark/BookmarkService.swift
@@ -1,0 +1,34 @@
+//
+//  BookmarkService.swift
+//  KAKAOBANK-iOS
+//
+//  Created by 윤희슬 on 5/21/24.
+//
+
+import Foundation
+
+import Moya
+
+protocol BookmarkServiceProtocol {
+    func postBookmarkState(myAccountId: Int, markedAccountId: Int, completion: @escaping (Int) -> Void)
+}
+
+final class BookmarkService: BaseService, BookmarkServiceProtocol {
+    
+    let provider = MoyaProvider<BookmarkTargetType>(plugins: [MoyaLoggingPlugin()])
+    
+    func postBookmarkState(myAccountId: Int,
+                           markedAccountId: Int,
+                           completion: @escaping (Int) -> Void) {
+        provider.request(.postBookmarkState(myAccountId: myAccountId, markedAccountId: markedAccountId)) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                completion(statusCode)
+            case .failure(let response):
+                completion(response.errorCode)
+            }
+        }
+    }
+
+}

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/Bookmark/BookmarkTargetType.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/Bookmark/BookmarkTargetType.swift
@@ -1,0 +1,41 @@
+//
+//  BookmarkTargetType.swift
+//  KAKAOBANK-iOS
+//
+//  Created by 윤희슬 on 5/21/24.
+//
+
+import Foundation
+
+import Moya
+
+enum BookmarkTargetType {
+    case postBookmarkState(myAccountId: Int, markedAccountId: Int)
+}
+
+extension BookmarkTargetType: BaseTargetType {
+    
+    var utilPath: String {
+        return "/api/v1/recent-transfers/"
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .postBookmarkState:
+            return .post
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .postBookmarkState(let myAccountId, let markedAccountId):
+            return utilPath + "\(myAccountId)/bookmark/\(markedAccountId)"
+        }
+    }
+    
+    var task: Moya.Task {
+        return .requestPlain
+    }
+    
+    
+}

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/Bookmark/DTO/BookmarkTargetType.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/Bookmark/DTO/BookmarkTargetType.swift
@@ -1,8 +1,0 @@
-//
-//  BookmarkTargetType.swift
-//  KAKAOBANK-iOS
-//
-//  Created by 윤희슬 on 5/21/24.
-//
-
-import Foundation

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/Bookmark/DTO/BookmarkTargetType.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/Bookmark/DTO/BookmarkTargetType.swift
@@ -1,0 +1,8 @@
+//
+//  BookmarkTargetType.swift
+//  KAKAOBANK-iOS
+//
+//  Created by 윤희슬 on 5/21/24.
+//
+
+import Foundation

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/Transfer/TransferTargetType.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/Transfer/TransferTargetType.swift
@@ -33,8 +33,5 @@ extension TransferTargetType: BaseTargetType {
     var task: Moya.Task {
         return .requestPlain
     }
-    
 
-    
-    
 }

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/Cells/RecentTransferCell.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/Cells/RecentTransferCell.swift
@@ -11,7 +11,7 @@ import SnapKit
 import Then
 
 protocol RecentTransferDelegate: AnyObject {
-    func changeFavoriteButtonState(_ cell: RecentTransferCell)
+    func changeFavoriteButtonState(_ cell: RecentTransferCell, markedButtonId: Int)
 }
 
 final class RecentTransferCell: UICollectionViewCell {
@@ -33,6 +33,11 @@ final class RecentTransferCell: UICollectionViewCell {
         }
     }
     
+    var markedButtonId: Int = 0 {
+        didSet {
+            self.favoriteButton.tag = markedButtonId
+        }
+    }
     
     // MARK: - LifeCycles
     
@@ -61,7 +66,7 @@ final class RecentTransferCell: UICollectionViewCell {
     
     @objc
     func didTapFavoriteButton() {
-        self.delegate?.changeFavoriteButtonState(self)
+        self.delegate?.changeFavoriteButtonState(self, markedButtonId: self.markedButtonId)
     }
 }
 

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/Models/AccountInfoModel.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/Models/AccountInfoModel.swift
@@ -18,16 +18,6 @@ struct AccountInfoModel {
 
 extension AccountInfoModel {
     
-//    static let myAccountInfoAppData:  [AccountInfoModel] = [
-//        AccountInfoModel(bankImg: .btnKakaoBankIos, bankbookName: "윤희슬의 통장", accountNumber: "카카오뱅크 3333-23-9165754")
-//    ]
-//    
-//    static let recentTransferInfoAppData:  [AccountInfoModel] = [
-//        AccountInfoModel(bankImg: .btnNonghupBankIos, bankbookName: "윤희슬", accountNumber: "농협 3333-23-9165754"),
-//        AccountInfoModel(bankImg: .btnKakaoBankIos, bankbookName: "김민서", accountNumber: "카카오 뱅크 3333-23-9165754"),
-//        AccountInfoModel(bankImg: .btnKukminBankIos, bankbookName: "오서영", accountNumber: "국민 3333-23-9165754")
-//    ]
-    
         static let myAccountInfoAppData:  [AccountInfoModel] = [
             AccountInfoModel(accountName: "윤희슬의 통장", accountNumber: 3333239165754, isAccountLike: false, bankName: "카카오뱅크", imgURL: "",  accountID: 1)
         ]

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/ViewControllers/TransferViewController.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/ViewControllers/TransferViewController.swift
@@ -180,6 +180,18 @@ private extension TransferViewController {
             }
         }
     }
+    
+    func postBookmarkState(markedButtonId: Int, cell: RecentTransferCell) {
+        NetworkService.shared.bookmarkService.postBookmarkState(myAccountId: 1, markedAccountId: markedButtonId) { result in
+            switch result {
+            case 200:
+                cell.isFavorite = !cell.isFavorite
+            default:
+                print("에러입니다")
+            }
+        }
+    }
+    
 }
 
 
@@ -206,8 +218,8 @@ extension TransferViewController: InputAccountButtonDelegate {
 
 extension TransferViewController: RecentTransferDelegate {
     
-    func changeFavoriteButtonState(_ cell: RecentTransferCell) {
-        cell.isFavorite = !cell.isFavorite
+    func changeFavoriteButtonState(_ cell: RecentTransferCell, markedButtonId: Int) {
+        self.postBookmarkState(markedButtonId: markedButtonId, cell: cell)
     }
     
 }
@@ -250,6 +262,8 @@ extension TransferViewController: UICollectionViewDataSource {
         case .recentTransfer:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RecentTransferCell.cellIdentifier, for: indexPath) as? RecentTransferCell else { return UICollectionViewCell() }
             cell.accountInfoView.bindAccountInfo(data: recentTransferData[indexPath.row])
+            cell.isFavorite = recentTransferData[indexPath.row].isAccountLike
+            cell.markedButtonId = recentTransferData[indexPath.row].accountID
             cell.delegate = self
             return cell
         }

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/ViewControllers/TransferViewController.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/ViewControllers/TransferViewController.swift
@@ -208,7 +208,6 @@ extension TransferViewController: TransferNaviBarDelegate {
 extension TransferViewController: InputAccountButtonDelegate {
     
     func pushToSelectBankVC() {
-        print("tap pushToSelectBankVC")
         let selectBankVC = SelectBankViewController()
         selectBankVC.modalPresentationStyle = .overFullScreen
         self.present(selectBankVC, animated: true)
@@ -219,7 +218,11 @@ extension TransferViewController: InputAccountButtonDelegate {
 extension TransferViewController: RecentTransferDelegate {
     
     func changeFavoriteButtonState(_ cell: RecentTransferCell, markedButtonId: Int) {
-        self.postBookmarkState(markedButtonId: markedButtonId, cell: cell)
+        if !cell.isFavorite {
+            self.postBookmarkState(markedButtonId: markedButtonId, cell: cell)
+        } else {
+            // 즐겨찾기 해제 서버 통신
+        }
     }
     
 }

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/Views/AccountInfoView.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/Views/AccountInfoView.swift
@@ -42,8 +42,11 @@ final class AccountInfoView: UIView {
     }
     
     func bindAccountInfo(data: AccountInfoModel) {
-        guard let url = URL(string: data.imgURL) else { return }
-        self.bankImageView.kf.setImage(with: url)
+        if let url = URL(string: data.imgURL) {
+            self.bankImageView.kf.setImage(with: url)
+        } else {
+            self.bankImageView.image = UIImage(resource: .btnKakaoBankIos)
+        }
         self.bankbookNameLabel.attributedText = UILabel.attributedText(for: .body4, withText: data.accountName)
         self.accountNumberLabel.attributedText = UILabel.attributedText(for: .body8, withText: "\(data.bankName) \(data.accountNumber)")
     }

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/Views/AccountInfoView.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/Views/AccountInfoView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import Kingfisher
 import SnapKit
 import Then
 
@@ -41,8 +42,8 @@ final class AccountInfoView: UIView {
     }
     
     func bindAccountInfo(data: AccountInfoModel) {
-        // 추후 이미지 세팅 수정
-        self.bankImageView.image = UIImage(resource: .btnKakaoBankIos)
+        guard let url = URL(string: data.imgURL) else { return }
+        self.bankImageView.kf.setImage(with: url)
         self.bankbookNameLabel.attributedText = UILabel.attributedText(for: .body4, withText: data.accountName)
         self.accountNumberLabel.attributedText = UILabel.attributedText(for: .body8, withText: "\(data.bankName) \(data.accountNumber)")
     }
@@ -81,6 +82,7 @@ private extension AccountInfoView {
         bankImageView.do {
             $0.clipsToBounds = true
             $0.layer.cornerRadius = 21
+            $0.contentMode = .scaleAspectFit
         }
         
         labelStackView.do {


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- feature/#52

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
즐겨찾기 등록 서버 통신

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### 1. 즐겨찾기 등록
```Swift
// 즐겨찾기 등록 서버 통신 메소드
func postBookmarkState(markedButtonId: Int, cell: RecentTransferCell) {
    NetworkService.shared.bookmarkService.postBookmarkState(myAccountId: 1, markedAccountId: markedButtonId) { result in
       // 서버 통신의 response로 받아오는 것이 없어서 statusCode로 분기처리 해주었습니다
        switch result {
        case 200:
           // 버튼의 상태를 바꿔주고 스타일도 바꿔줍니다
            cell.isFavorite = !cell.isFavorite
        default:
            print("에러입니다")
        }
    }
}

// 셀 내부에 있는 버튼 액션을 델리게이트로 분리
extension TransferViewController: RecentTransferDelegate {
    
    func changeFavoriteButtonState(_ cell: RecentTransferCell, markedButtonId: Int) {
       if !cell.isFavorite {
            self.postBookmarkState(markedButtonId: markedButtonId, cell: cell)
        } else {
            // 즐겨찾기 해제 서버 통신
        }
    }
    
}
```

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰15Pro|<img src = "https://github.com/NOW-SOPT-APP2-KAKAOBANK/KAKAOBANK-iOS/assets/105407130/5618a3a1-71c3-4a14-ad6b-90bbcb28da75" width = "70%"/>|



## 📟 관련 이슈
- Resolved: #52 
