### PR TITLE
[Feat] 내 계좌 정보 조회 API 연동 (#47)

### DIFF
--- a/KAKAOBANK-iOS/KAKAOBANK-iOS.xcodeproj/project.pbxproj
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		0D357E202BF3CB4000E044BB /* StickyHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D357E1F2BF3CB4000E044BB /* StickyHeaderView.swift */; };
 		0D357E242BF3DFE000E044BB /* BankAccountTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D357E232BF3DFE000E044BB /* BankAccountTableViewCell.swift */; };
 		0D357E262BF3E7B100E044BB /* BankAccountModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D357E252BF3E7B100E044BB /* BankAccountModel.swift */; };
+		0D3F13562BFDB38B00B2685E /* MyAccountService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D3F13552BFDB38B00B2685E /* MyAccountService.swift */; };
+		0D3F13582BFDB3E500B2685E /* MyAccountTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D3F13572BFDB3E500B2685E /* MyAccountTargetType.swift */; };
+		0D3F135C2BFDB8DF00B2685E /* GetMyAccountResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D3F135B2BFDB8DF00B2685E /* GetMyAccountResponse.swift */; };
 		0D5AB9052BF2663C00C41046 /* BankAccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5AB9042BF2663C00C41046 /* BankAccountViewController.swift */; };
 		0D5AB9072BF267E700C41046 /* BankAccountNaviBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5AB9062BF267E700C41046 /* BankAccountNaviBar.swift */; };
 		0DB63ACA2BF7565D007AA8C8 /* BankAccountUpperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB63AC92BF7565D007AA8C8 /* BankAccountUpperView.swift */; };
@@ -82,6 +85,9 @@
 		0D357E1F2BF3CB4000E044BB /* StickyHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickyHeaderView.swift; sourceTree = "<group>"; };
 		0D357E232BF3DFE000E044BB /* BankAccountTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankAccountTableViewCell.swift; sourceTree = "<group>"; };
 		0D357E252BF3E7B100E044BB /* BankAccountModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankAccountModel.swift; sourceTree = "<group>"; };
+		0D3F13552BFDB38B00B2685E /* MyAccountService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAccountService.swift; sourceTree = "<group>"; };
+		0D3F13572BFDB3E500B2685E /* MyAccountTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAccountTargetType.swift; sourceTree = "<group>"; };
+		0D3F135B2BFDB8DF00B2685E /* GetMyAccountResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetMyAccountResponse.swift; sourceTree = "<group>"; };
 		0D5AB9042BF2663C00C41046 /* BankAccountViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankAccountViewController.swift; sourceTree = "<group>"; };
 		0D5AB9062BF267E700C41046 /* BankAccountNaviBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankAccountNaviBar.swift; sourceTree = "<group>"; };
 		0DB63AC92BF7565D007AA8C8 /* BankAccountUpperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankAccountUpperView.swift; sourceTree = "<group>"; };
@@ -178,6 +184,24 @@
 				0D357E252BF3E7B100E044BB /* BankAccountModel.swift */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		0D3F13542BFDB36E00B2685E /* MyAccount */ = {
+			isa = PBXGroup;
+			children = (
+				0D3F135A2BFDB87C00B2685E /* DTO */,
+				0D3F13552BFDB38B00B2685E /* MyAccountService.swift */,
+				0D3F13572BFDB3E500B2685E /* MyAccountTargetType.swift */,
+			);
+			path = MyAccount;
+			sourceTree = "<group>";
+		};
+		0D3F135A2BFDB87C00B2685E /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				0D3F135B2BFDB8DF00B2685E /* GetMyAccountResponse.swift */,
+			);
+			path = DTO;
 			sourceTree = "<group>";
 		};
 		0D5AB9012BF264B700C41046 /* BankAccount */ = {
@@ -303,6 +327,7 @@
 		CA0C2CD22BFC7C7B0026C6C7 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				0D3F13542BFDB36E00B2685E /* MyAccount */,
 				CA0C2CE92BFCE8400026C6C7 /* Bookmark */,
 				CA0C2CDF2BFC85BA0026C6C7 /* Transfer */,
 				CA0C2CD32BFC7C810026C6C7 /* Base */,
@@ -609,6 +634,7 @@
 				2CF9BFF32BF48A6100C7BC35 /* SecondAccountView.swift in Sources */,
 				CA05B3A52BF27C1B00DA77E1 /* AccountInfoView.swift in Sources */,
 				CA22B3FD2BF147040013B7AB /* UIStackView+.swift in Sources */,
+				0D3F135C2BFDB8DF00B2685E /* GetMyAccountResponse.swift in Sources */,
 				CA0C2CE52BFC88B90026C6C7 /* NetworkService.swift in Sources */,
 				CA22B3F72BF1379B0013B7AB /* UIFont+.swift in Sources */,
 				CA05B3AC2BF2A50C00DA77E1 /* InputAccountButton.swift in Sources */,
@@ -645,6 +671,7 @@
 				CAD398732BECED3F00B57329 /* AppDelegate.swift in Sources */,
 				CA2CBDF42BF6677000049F8F /* BankListCell.swift in Sources */,
 				2CF9BFF12BF47A0C00C7BC35 /* MainAccountView.swift in Sources */,
+				0D3F13562BFDB38B00B2685E /* MyAccountService.swift in Sources */,
 				2C28353F2BF5294D00245FE1 /* SimpleBarView.swift in Sources */,
 				2C2835392BF5239700245FE1 /* SavingsView.swift in Sources */,
 				0D357E262BF3E7B100E044BB /* BankAccountModel.swift in Sources */,
@@ -655,6 +682,7 @@
 				CAD398752BECED3F00B57329 /* SceneDelegate.swift in Sources */,
 				2CF9BFED2BF440F900C7BC35 /* HeaderView.swift in Sources */,
 				0D357E242BF3DFE000E044BB /* BankAccountTableViewCell.swift in Sources */,
+				0D3F13582BFDB3E500B2685E /* MyAccountTargetType.swift in Sources */,
 				CA6B4FA42BF210D1009A641D /* Constants.swift in Sources */,
 				CA51DE892BF202B10084E610 /* TransferViewController.swift in Sources */,
 				CA6B4FA62BF2141D009A641D /* SectionHeaderView.swift in Sources */,

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "6cff3f6b7c264d53af1d216bc25530a1cda9d3e1d07ca6b23c15aa5524431c46",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -65,5 +64,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/Base/NetworkService.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/Base/NetworkService.swift
@@ -16,4 +16,5 @@ final class NetworkService {
     let transferService: TransferService = TransferService()
     
     let bookmarkService: BookmarkService = BookmarkService()
+
 }

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/MyAccount/DTO/GetMyAccountResponse.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/MyAccount/DTO/GetMyAccountResponse.swift
@@ -1,0 +1,16 @@
+//
+//  GetMyAccountResponse.swift
+//  KAKAOBANK-iOS
+//
+//  Created by 김민서 on 5/22/24.
+//
+
+import Foundation
+
+struct GetMyAccountResponse: Codable {
+    let accountName: String
+    let balance: Int
+    let accountNumber: Int
+}
+
+

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/MyAccount/MyAccountService.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/MyAccount/MyAccountService.swift
@@ -1,0 +1,35 @@
+//
+//  MyAccountService.swift
+//  KAKAOBANK-iOS
+//
+//  Created by 김민서 on 5/22/24.
+//
+
+import Foundation
+
+import Moya
+
+
+protocol MyAccountServiceProtocol {
+    func getMyAccount(accountId: Int, completion: @escaping (NetworkResult<GetMyAccountResponse>) -> Void)
+}
+
+final class MyAccountService: BaseService, MyAccountServiceProtocol {
+    static let shared = MyAccountService()
+    let provider = MoyaProvider<MyAccountTargetType>(plugins: [MoyaLoggingPlugin()])
+    
+    func getMyAccount(accountId: Int, completion: @escaping (NetworkResult<GetMyAccountResponse>) -> Void) {
+        provider.request(.getMyAccountInfo(accountId: accountId)) { response in
+            switch response {
+            case .success(let result):
+                let statusCode = result.statusCode
+                let data = result.data
+                
+                let networkResult: NetworkResult<GetMyAccountResponse> = self.judgeStatus(statusCode: statusCode, data: data)
+                completion(networkResult)
+            case .failure:
+                completion(.networkFail)
+            }
+        }
+    }
+}

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/MyAccount/MyAccountTargetType.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/MyAccount/MyAccountTargetType.swift
@@ -1,0 +1,45 @@
+//
+//  MyAccountTargetType.swift
+//  KAKAOBANK-iOS
+//
+//  Created by 김민서 on 5/22/24.
+//
+
+import Foundation
+
+import Moya
+
+enum MyAccountTargetType {
+    case getMyAccountInfo(accountId: Int)
+}
+
+extension MyAccountTargetType: TargetType {
+    var baseURL: URL {
+        return URL(string: Config.baseURL)!
+    }
+    
+    var path: String {
+        switch self {
+        case .getMyAccountInfo(let accountId):
+            return "/api/v1/account-info/\(accountId)"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .getMyAccountInfo:
+            return .get
+        }
+    }
+    
+    var task: Moya.Task {
+        switch self {
+        case .getMyAccountInfo:
+            return .requestPlain
+        }
+    }
+    
+    var headers: [String : String]? {
+        return ["Content-Type": "application/json"]
+    }
+}

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/ViewControllers/BankAccountViewController.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/ViewControllers/BankAccountViewController.swift
@@ -10,13 +10,6 @@ import UIKit
 import SnapKit
 import Then
 
-struct AccountData {
-    var accountName: String
-    var balance: Int
-    var accountNumber: String
-}
-
-
 
 final class BankAccountViewController: UIViewController {
     

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/ViewControllers/BankAccountViewController.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/ViewControllers/BankAccountViewController.swift
@@ -10,6 +10,13 @@ import UIKit
 import SnapKit
 import Then
 
+struct AccountData {
+    var accountName: String
+    var balance: Int
+    var accountNumber: String
+}
+
+
 
 final class BankAccountViewController: UIViewController {
     
@@ -24,9 +31,7 @@ final class BankAccountViewController: UIViewController {
     private let headerView = StickyHeaderView()
     
     private let backgroundView = UIView()
-    
-    
-    
+
     
     private let bankAccountList = BankAccountModel.dummy()
     
@@ -66,9 +71,11 @@ private extension BankAccountViewController {
         MyAccountService.shared.getMyAccount(accountId: 1) { result in
             switch result {
             case .success(let data):
+                let formattedAccount = self.formatAccount("\(data.accountNumber)")
+                
                 self.bankAccountNaviBar.titleLabel.text = data.accountName
                 self.bankAccountUpperView.balanceLabel.text = "\(data.balance)"
-                self.bankAccountUpperView.accountLabel.text = "\(data.accountNumber)"
+                self.bankAccountUpperView.accountLabel.text = formattedAccount
                 
             case .requestErr:
                 print("요청 오류입니다")
@@ -82,6 +89,18 @@ private extension BankAccountViewController {
                 print("네트워크 오류입니다")
             }
         }
+    }
+
+    //계좌번호 사이 - 추가를 위한 메서드
+    func formatAccount(_ accountNumber: String) -> String {
+        var formattedAccount = ""
+        for (index, char) in accountNumber.enumerated() {
+            if index == 4 || index == 6 {
+                formattedAccount.append("-")
+            }
+            formattedAccount.append(char)
+        }
+        return formattedAccount
     }
 
     

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/ViewControllers/BankAccountViewController.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/ViewControllers/BankAccountViewController.swift
@@ -26,7 +26,7 @@ final class BankAccountViewController: UIViewController {
     private let backgroundView = UIView()
     
     
-
+    
     
     private let bankAccountList = BankAccountModel.dummy()
     
@@ -38,13 +38,14 @@ final class BankAccountViewController: UIViewController {
         setStyle()
         setDelegate()
         register()
+        getMyAccount()
         configureRefreshControl()
     }
     
     
     override func viewWillAppear(_ animated: Bool) {
         self.navigationController?.setNavigationBarHidden(true, animated: false)
-
+        
         bankAccountTableView.reloadData()
         
         let conetentHeight = CGFloat(bankAccountList.count) * 87
@@ -60,6 +61,29 @@ final class BankAccountViewController: UIViewController {
 }
 
 private extension BankAccountViewController {
+  
+    func getMyAccount() {
+        MyAccountService.shared.getMyAccount(accountId: 1) { result in
+            switch result {
+            case .success(let data):
+                self.bankAccountNaviBar.titleLabel.text = data.accountName
+                self.bankAccountUpperView.balanceLabel.text = "\(data.balance)"
+                self.bankAccountUpperView.accountLabel.text = "\(data.accountNumber)"
+                
+            case .requestErr:
+                print("요청 오류입니다")
+            case .decodedErr:
+                print("디코딩 오류입니다")
+            case .pathErr:
+                print("경로 오류입니다")
+            case .serverErr:
+                print("서버 오류입니다")
+            case .networkFail:
+                print("네트워크 오류입니다")
+            }
+        }
+    }
+
     
     func setHierarchy() {
         self.view.addSubviews(backgroundView,scrollView,bankAccountNaviBar, headerView)
@@ -118,7 +142,7 @@ private extension BankAccountViewController {
         self.view.backgroundColor = UIColor(resource: .main)
         self.navigationController?.isNavigationBarHidden = true
         bankAccountTableView.isScrollEnabled = true
-     
+        
         backgroundView.backgroundColor = .white
         
         stickyHeaderView.do {
@@ -162,7 +186,7 @@ private extension BankAccountViewController {
     @objc func handleRefreshControl() {
         //진동 추가
         let feedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
-                feedbackGenerator.impactOccurred()
+        feedbackGenerator.impactOccurred()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
             self.scrollView.refreshControl?.endRefreshing()
         }
@@ -211,3 +235,4 @@ extension BankAccountViewController: BankAccountUpperViewDelegate {
         self.navigationController?.pushViewController(transferVC, animated: true)
     }
 }
+

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/Views/BankAccountNaviBar.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/Views/BankAccountNaviBar.swift
@@ -17,7 +17,7 @@ protocol BankAccountNaviBarDelegate: AnyObject {
 final class BankAccountNaviBar: UIView {
     
     private let backButton = UIButton()
-    private let titleLabel = UILabel()
+    let titleLabel = UILabel()
     private let settingButton = UIButton()
     
     weak var delegate: BankAccountNaviBarDelegate?

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/Views/BankAccountUpperView.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/Views/BankAccountUpperView.swift
@@ -16,9 +16,9 @@ protocol BankAccountUpperViewDelegate: AnyObject {
 
 final class BankAccountUpperView: UIView {
     
-    private var accountLabel = UILabel()
+    var accountLabel = UILabel()
     private var underlineLabel = UILabel()
-    private var balanceLabel = UILabel()
+    var balanceLabel = UILabel()
     private var wonLabel = UILabel()
     private var transferButton  = UIButton()
     private var takeButton = UIButton()


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- feature/#47

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
내 계좌 정보 조회 API 연동했습니당

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
받아올 데이터가 어떤 구조인지 잘 확인해야함을 알게 되었슴니닷..ㅎㅎ

계좌번호가 문자열이 아닌 정수로 와서 계좌번호 사이에 "-"가 추가될 수 있는 메서드 구현했습니다!
아직 서버에서 주는 더미가 짧아서 시뮬레이터에서는 보이지 않습니다

```
 func formatAccount(_ accountNumber: String) -> String {
        var formattedAccount = ""
        for (index, char) in accountNumber.enumerated() {
            if index == 4 || index == 6 {
                formattedAccount.append("-")
            }
            formattedAccount.append(char)
        }
        return formattedAccount
    }
```

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰15Pro|![Simulator Screen Recording - iPhone 15 Pro - 2024-05-22 at 17 25 22](https://github.com/NOW-SOPT-APP2-KAKAOBANK/KAKAOBANK-iOS/assets/105372558/c34e1153-0459-4a67-9760-6be53204b9cd)|



## 📟 관련 이슈
- Resolved: #47 
