### PR TITLE
[Feat] 메인 페이지, 이체 화면 API 총 두 개 연결(#49)

### DIFF
--- a/KAKAOBANK-iOS/KAKAOBANK-iOS.xcodeproj/project.pbxproj
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS.xcodeproj/project.pbxproj
@@ -22,6 +22,9 @@
 		2C28353F2BF5294D00245FE1 /* SimpleBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C28353E2BF5294D00245FE1 /* SimpleBarView.swift */; };
 		2C3F78602BF5EC28005AF799 /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3F785F2BF5EC28005AF799 /* MainTabBarController.swift */; };
 		2C3F78622BF60A05005AF799 /* AddView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3F78612BF60A05005AF799 /* AddView.swift */; };
+		2CD3F19B2BFE247C00596073 /* GetMainAccountResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD3F19A2BFE247C00596073 /* GetMainAccountResponse.swift */; };
+		2CD3F19D2BFE249400596073 /* MainAccountService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD3F19C2BFE249400596073 /* MainAccountService.swift */; };
+		2CD3F19F2BFE249F00596073 /* MainAccountTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD3F19E2BFE249F00596073 /* MainAccountTargetType.swift */; };
 		2CF8D8972BF6306D00784038 /* TipsCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF8D8962BF6306D00784038 /* TipsCollectionViewCell.swift */; };
 		2CF8D8992BF6311100784038 /* TipsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF8D8982BF6311100784038 /* TipsViewController.swift */; };
 		2CF8D89C2BF6387E00784038 /* TipsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF8D89B2BF6387E00784038 /* TipsModel.swift */; };
@@ -97,6 +100,9 @@
 		2C28353E2BF5294D00245FE1 /* SimpleBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleBarView.swift; sourceTree = "<group>"; };
 		2C3F785F2BF5EC28005AF799 /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
 		2C3F78612BF60A05005AF799 /* AddView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddView.swift; sourceTree = "<group>"; };
+		2CD3F19A2BFE247C00596073 /* GetMainAccountResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetMainAccountResponse.swift; sourceTree = "<group>"; };
+		2CD3F19C2BFE249400596073 /* MainAccountService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainAccountService.swift; sourceTree = "<group>"; };
+		2CD3F19E2BFE249F00596073 /* MainAccountTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainAccountTargetType.swift; sourceTree = "<group>"; };
 		2CF8D8962BF6306D00784038 /* TipsCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipsCollectionViewCell.swift; sourceTree = "<group>"; };
 		2CF8D8982BF6311100784038 /* TipsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipsViewController.swift; sourceTree = "<group>"; };
 		2CF8D89B2BF6387E00784038 /* TipsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipsModel.swift; sourceTree = "<group>"; };
@@ -233,6 +239,24 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		2CD3F1982BFE246300596073 /* MainAccount */ = {
+			isa = PBXGroup;
+			children = (
+				2CD3F1992BFE246A00596073 /* DTO */,
+				2CD3F19C2BFE249400596073 /* MainAccountService.swift */,
+				2CD3F19E2BFE249F00596073 /* MainAccountTargetType.swift */,
+			);
+			path = MainAccount;
+			sourceTree = "<group>";
+		};
+		2CD3F1992BFE246A00596073 /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				2CD3F19A2BFE247C00596073 /* GetMainAccountResponse.swift */,
+			);
+			path = DTO;
+			sourceTree = "<group>";
+		};
 		2CF8D8942BF62F2600784038 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
@@ -327,6 +351,7 @@
 		CA0C2CD22BFC7C7B0026C6C7 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				2CD3F1982BFE246300596073 /* MainAccount */,
 				0D3F13542BFDB36E00B2685E /* MyAccount */,
 				CA0C2CE92BFCE8400026C6C7 /* Bookmark */,
 				CA0C2CDF2BFC85BA0026C6C7 /* Transfer */,
@@ -622,6 +647,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2C28353D2BF523AD00245FE1 /* MeetingAccountView.swift in Sources */,
+				2CD3F19F2BFE249F00596073 /* MainAccountTargetType.swift in Sources */,
 				0D357E202BF3CB4000E044BB /* StickyHeaderView.swift in Sources */,
 				CA22B4012BF147BF0013B7AB /* UITableViewCell.swift in Sources */,
 				CA22B3FD2BF147040013B7AB /* UIStackView+.swift in Sources */,
@@ -654,6 +680,7 @@
 				CA05B3A32BF27AF300DA77E1 /* MyAccountCell.swift in Sources */,
 				CA0C2CE82BFC8C9E0026C6C7 /* GetRecentTransferResponseDTO.swift in Sources */,
 				0DB63ACA2BF7565D007AA8C8 /* BankAccountUpperView.swift in Sources */,
+				2CD3F19D2BFE249400596073 /* MainAccountService.swift in Sources */,
 				CA0C2CEC2BFCE8550026C6C7 /* BookmarkService.swift in Sources */,
 				CA9982BC2BF5282600EC1F56 /* BottomSheetView.swift in Sources */,
 				CA05B3AA2BF2923700DA77E1 /* RecentTransferCell.swift in Sources */,
@@ -664,6 +691,7 @@
 				CA0C2CDA2BFC7DCD0026C6C7 /* MoyaLoggingPlugin.swift in Sources */,
 				0D5AB9072BF267E700C41046 /* BankAccountNaviBar.swift in Sources */,
 				2C28353B2BF523A000245FE1 /* AddButtonView.swift in Sources */,
+				2CD3F19B2BFE247C00596073 /* GetMainAccountResponse.swift in Sources */,
 				CA22B3F92BF13C380013B7AB /* UILabel+.swift in Sources */,
 				CA05B3A32BF27AF300DA77E1 /* MyAccountCell.swift in Sources */,
 				2C3F78602BF5EC28005AF799 /* MainTabBarController.swift in Sources */,

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "0cef3c7ca54ee862be15b98778c0b76d2dce99e9518b08e6570114cfe5986456",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -64,5 +65,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/Base/NetworkService.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/Base/NetworkService.swift
@@ -16,5 +16,7 @@ final class NetworkService {
     let transferService: TransferService = TransferService()
     
     let bookmarkService: BookmarkService = BookmarkService()
+    
+    let mainAccountService: MainAccountService = MainAccountService()
 
 }

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/MainAccount/DTO/GetMainAccountResponse.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/MainAccount/DTO/GetMainAccountResponse.swift
@@ -1,0 +1,13 @@
+//
+//  RequestDTO.swift
+//  KAKAOBANK-iOS
+//
+//  Created by 오서영 on 5/22/24.
+//
+import Foundation
+
+struct GetMainAccountResponse: Codable {
+    let accountName: String
+    let balance: Int
+    let accountNumber: Int
+}

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/MainAccount/MainAccountService.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/MainAccount/MainAccountService.swift
@@ -9,13 +9,13 @@ import Foundation
 import Moya
 
 protocol MainAccountServiceProtocol {
-    func getAccountInfo(accountId: Int, completion: @escaping (Result<GetMainAccountResponse, Error>) -> Void)
+    func getAccountInfo(accountId: Int, completion: @escaping (NetworkResult<GetMainAccountResponse>) -> Void)
 }
 
 final class MainAccountService: MainAccountServiceProtocol {
     private let provider = MoyaProvider<MainAccountTargetType>()
-    
-    func getAccountInfo(accountId: Int, completion: @escaping (Result<GetMainAccountResponse, Error>) -> Void) {
+        
+    func getAccountInfo(accountId: Int, completion: @escaping (NetworkResult<GetMainAccountResponse>) -> Void) {
         provider.request(.getAccountInfo(accountId: accountId)) { result in
             switch result {
             case .success(let response):
@@ -23,10 +23,32 @@ final class MainAccountService: MainAccountServiceProtocol {
                     let accountInfo = try JSONDecoder().decode(GetMainAccountResponse.self, from: response.data)
                     completion(.success(accountInfo))
                 } catch {
-                    completion(.failure(error))
+                    completion(.decodedErr)
                 }
             case .failure(let error):
-                completion(.failure(error))
+                if let moyaError = error as? MoyaError {
+                    switch moyaError {
+                    case .underlying(let nsError as NSError, _):
+                        if nsError.domain == NSURLErrorDomain {
+                            completion(.networkFail)
+                        } else {
+                            completion(.serverErr)
+                        }
+                    case .statusCode(let response):
+                        switch response.statusCode {
+                        case 400..<500:
+                            completion(.requestErr)
+                        case 500..<600:
+                            completion(.serverErr)
+                        default:
+                            completion(.pathErr)
+                        }
+                    default:
+                        completion(.pathErr)
+                    }
+                } else {
+                    completion(.pathErr)
+                }
             }
         }
     }

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/MainAccount/MainAccountService.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/MainAccount/MainAccountService.swift
@@ -1,0 +1,33 @@
+//
+//  MainAccountService.swift
+//  KAKAOBANK-iOS
+//
+//  Created by 오서영 on 5/22/24.
+//
+
+import Foundation
+import Moya
+
+protocol MainAccountServiceProtocol {
+    func getAccountInfo(accountId: Int, completion: @escaping (Result<GetMainAccountResponse, Error>) -> Void)
+}
+
+final class MainAccountService: MainAccountServiceProtocol {
+    private let provider = MoyaProvider<MainAccountTargetType>()
+    
+    func getAccountInfo(accountId: Int, completion: @escaping (Result<GetMainAccountResponse, Error>) -> Void) {
+        provider.request(.getAccountInfo(accountId: accountId)) { result in
+            switch result {
+            case .success(let response):
+                do {
+                    let accountInfo = try JSONDecoder().decode(GetMainAccountResponse.self, from: response.data)
+                    completion(.success(accountInfo))
+                } catch {
+                    completion(.failure(error))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+}

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/MainAccount/MainAccountTargetType.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/MainAccount/MainAccountTargetType.swift
@@ -1,0 +1,38 @@
+//
+//  MainAccountTargetType.swift
+//  KAKAOBANK-iOS
+//
+//  Created by 오서영 on 5/22/24.
+//
+
+import Foundation
+import Moya
+
+enum MainAccountTargetType {
+    case getAccountInfo(accountId: Int)
+}
+
+extension MainAccountTargetType: BaseTargetType {
+    
+    var utilPath: String {
+        return "/api/v1/"
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .getAccountInfo:
+            return .get
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .getAccountInfo(let accountId):
+            return utilPath + "account-info/\(accountId)"
+        }
+    }
+    
+    var task: Moya.Task {
+        return .requestPlain
+    }
+}

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/Transfer/TransferService.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/Transfer/TransferService.swift
@@ -11,6 +11,7 @@ import Moya
 
 protocol TransferServiceProtocol {
     func getRecentTransfer(accountId: Int, completion: @escaping (NetworkResult<[GetRecentTransferResponseDTO]>) -> Void)
+    func deleteBookmarkState(myAccountId: Int, markedAccountId: Int, completion: @escaping (Int) -> Void)
 }
 
 final class TransferService: BaseService, TransferServiceProtocol {
@@ -28,6 +29,18 @@ final class TransferService: BaseService, TransferServiceProtocol {
                 completion(networkResult)
             case .failure:
                 completion(.networkFail)
+            }
+        }
+    }
+    
+    func deleteBookmarkState(myAccountId: Int, markedAccountId: Int, completion: @escaping (Int) -> Void) {
+        provider.request(.deleteBookmarkState(myAccountId: myAccountId, markedAccountId: markedAccountId)) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                completion(statusCode)
+            case .failure(let response):
+                completion(response.errorCode)
             }
         }
     }

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/Transfer/TransferTargetType.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/Transfer/TransferTargetType.swift
@@ -11,6 +11,7 @@ import Moya
 
 enum TransferTargetType {
     case getRecentTransfers(accountId: Int)
+    case deleteBookmarkState(myAccountId: Int, markedAccountId: Int)
 }
 
 extension TransferTargetType: BaseTargetType {
@@ -20,13 +21,20 @@ extension TransferTargetType: BaseTargetType {
     }
     
     var method: Moya.Method {
-        return .get
+        switch self {
+        case .getRecentTransfers:
+            return .get
+        case .deleteBookmarkState:
+            return .delete
+        }
     }
     
     var path: String {
         switch self {
         case .getRecentTransfers(let accountId):
             return utilPath + "recent-transfers/\(accountId)"
+        case .deleteBookmarkState(let myAccountId, let markedAccountId):
+            return utilPath + "recent-transfers/\(myAccountId)/bookmark/\(markedAccountId)"
         }
     }
     

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/ViewControllers/MainViewController.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/ViewControllers/MainViewController.swift
@@ -23,8 +23,6 @@ class MainViewController: UIViewController {
     
     private var headerViewTopConstraint: Constraint?
     
-    private let mainAccountService: MainAccountServiceProtocol = MainAccountService()
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         setDelegate()
@@ -161,38 +159,39 @@ class MainViewController: UIViewController {
     }
     
     private func getAccountInfo() {
-        mainAccountService.getAccountInfo(accountId: 1) { result in
+        NetworkService.shared.mainAccountService.getAccountInfo(accountId: 1) { result in
             switch result {
             case .success(let response):
                 DispatchQueue.main.async {
                     self.mainAccountView.configure(with: response)
                 }
-            case .failure(let error):
-                print("Failed to fetch account info: \(error.localizedDescription)")
+            default:
+                print("Failed to fetch account info")
             }
         }
         
-        mainAccountService.getAccountInfo(accountId: 2) { result in
+        NetworkService.shared.mainAccountService.getAccountInfo(accountId: 2) { result in
             switch result {
             case .success(let response):
                 DispatchQueue.main.async {
                     self.secondAccountView.configure(with: response)
                 }
-            case .failure(let error):
-                print("Failed to fetch account info: \(error.localizedDescription)")
+            default:
+                print("Failed to fetch account info")
             }
         }
         
-        mainAccountService.getAccountInfo(accountId: 3) { result in
+        NetworkService.shared.mainAccountService.getAccountInfo(accountId: 3) { result in
             switch result {
             case .success(let response):
                 DispatchQueue.main.async {
                     self.thirdAccountView.configure(with: response)
                 }
-            case .failure(let error):
-                print("Failed to fetch account info: \(error.localizedDescription)")
+            default:
+                print("Failed to fetch account info")
             }
         }
+    
     }
 }
 

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/ViewControllers/MainViewController.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/ViewControllers/MainViewController.swift
@@ -23,12 +23,15 @@ class MainViewController: UIViewController {
     
     private var headerViewTopConstraint: Constraint?
     
+    private let mainAccountService: MainAccountServiceProtocol = MainAccountService()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setDelegate()
         setStyle()
         setHierachy()
         setLayout()
+        getAccountInfo()
         
     }
     
@@ -155,6 +158,41 @@ class MainViewController: UIViewController {
             $0.bottom.equalToSuperview().offset(-20)
         }
         self.view.layoutIfNeeded()
+    }
+    
+    private func getAccountInfo() {
+        mainAccountService.getAccountInfo(accountId: 1) { result in
+            switch result {
+            case .success(let response):
+                DispatchQueue.main.async {
+                    self.mainAccountView.configure(with: response)
+                }
+            case .failure(let error):
+                print("Failed to fetch account info: \(error.localizedDescription)")
+            }
+        }
+        
+        mainAccountService.getAccountInfo(accountId: 2) { result in
+            switch result {
+            case .success(let response):
+                DispatchQueue.main.async {
+                    self.secondAccountView.configure(with: response)
+                }
+            case .failure(let error):
+                print("Failed to fetch account info: \(error.localizedDescription)")
+            }
+        }
+        
+        mainAccountService.getAccountInfo(accountId: 3) { result in
+            switch result {
+            case .success(let response):
+                DispatchQueue.main.async {
+                    self.thirdAccountView.configure(with: response)
+                }
+            case .failure(let error):
+                print("Failed to fetch account info: \(error.localizedDescription)")
+            }
+        }
     }
 }
 

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/Views/MainAccountView.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/Views/MainAccountView.swift
@@ -185,4 +185,9 @@ class MainAccountView: UIView {
             make.bottom.equalToSuperview().inset(21)
         }
     }
+    
+    func configure(with response: GetMainAccountResponse) {
+        titleLabel.text = response.accountName
+        balanceLabel.text = "\(response.balance)원"
+    }
 }

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/Views/SecondAccountView.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/Views/SecondAccountView.swift
@@ -79,4 +79,9 @@ class SecondAccountView: UIView {
             make.width.height.equalTo(24)
         }
     }
+    
+    func configure(with response: GetMainAccountResponse) {
+        titleLabel.text = response.accountName
+        balanceLabel.text = "\(response.balance)원"
+    }
 }

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/Views/ThirdAccountView.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/MainPage/Views/ThirdAccountView.swift
@@ -152,4 +152,9 @@ class ThirdAccountView: UIView {
             make.width.equalTo(48)
         }
     }
+    
+    func configure(with response: GetMainAccountResponse) {
+        titleLabel.text = response.accountName
+        balanceLabel.text = "\(response.balance)원"
+    }
 }

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/Cells/RecentTransferCell.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/Cells/RecentTransferCell.swift
@@ -29,6 +29,7 @@ final class RecentTransferCell: UICollectionViewCell {
     
     var isFavorite: Bool = false {
         didSet {
+            print("isFavorite 상태 변경: \(isFavorite)")
             changeButtonStyle()
         }
     }

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/Cells/RecentTransferCell.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/Cells/RecentTransferCell.swift
@@ -53,6 +53,14 @@ final class RecentTransferCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        self.isFavorite = false
+        self.markedButtonId = 0
+        self.favoriteButton.setImage(.icnStarOffIos, for: .normal)
+        self.favoriteButton.isSelected = false
+    }
+    
     func changeButtonStyle() {
         if isFavorite {
             self.favoriteButton.setImage(.icnStarOnIos, for: .normal)
@@ -68,6 +76,7 @@ final class RecentTransferCell: UICollectionViewCell {
     func didTapFavoriteButton() {
         self.delegate?.changeFavoriteButtonState(self, markedButtonId: self.markedButtonId)
     }
+    
 }
 
 

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/Cells/RecentTransferCell.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/Cells/RecentTransferCell.swift
@@ -53,13 +53,6 @@ final class RecentTransferCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        self.isFavorite = false
-        self.markedButtonId = 0
-        self.favoriteButton.setImage(.icnStarOffIos, for: .normal)
-        self.favoriteButton.isSelected = false
-    }
     
     func changeButtonStyle() {
         if isFavorite {

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/Models/AccountInfoModel.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/Models/AccountInfoModel.swift
@@ -10,10 +10,19 @@ import UIKit
 struct AccountInfoModel {
     let accountName: String
     let accountNumber: Int
-    let isAccountLike: Bool
+    var isAccountLike: Bool
     let bankName: String
     let imgURL: String
     let accountID: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case accountName
+        case accountNumber
+        case isAccountLike
+        case bankName
+        case imgURL = "imgUrl"
+        case accountID = "accountId"
+    }
 }
 
 extension AccountInfoModel {

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/ViewControllers/TransferViewController.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/ViewControllers/TransferViewController.swift
@@ -42,6 +42,7 @@ final class TransferViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         self.navigationController?.setNavigationBarHidden(false, animated: false)
         getRecentTransferList()
     }

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/ViewControllers/TransferViewController.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/ViewControllers/TransferViewController.swift
@@ -44,6 +44,7 @@ final class TransferViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.navigationController?.setNavigationBarHidden(false, animated: false)
+        print("viewWillAppear - 데이터 로드 시작")
         getRecentTransferList()
     }
 }
@@ -164,10 +165,12 @@ private extension TransferViewController {
     }
     
     func getRecentTransferList() {
+        print("getRecentTransferList - 데이터 로드 시작")
         self.recentTransferData.removeAll()
         NetworkService.shared.transferService.getRecentTransfer(accountId: 1) { result in
             switch result {
             case .success(let data):
+                print("getRecentTransferList - 데이터 로드 성공")
                 for i in data {
                     self.recentTransferData.append(AccountInfoModel(accountName: i.accountName,
                                                                     accountNumber: i.accountNumber,
@@ -176,13 +179,19 @@ private extension TransferViewController {
                                                                     imgURL: i.imgURL,
                                                                     accountID: i.accountID))
                 }
+                
+                DispatchQueue.main.async {
+                    print("getRecentTransferList - 컬렉션 뷰 리로드")
+                    self.transferCollectionView.reloadData()
+                }
             default:
-                print("에러입니다")
+                print("getRecentTransferList - 데이터 로드 에러")
             }
         }
     }
     
     func postBookmarkState(markedButtonId: Int, cell: RecentTransferCell) {
+        print("postBookmarkState - 요청 데이터: myAccountId: 1, markedAccountId: \(markedButtonId)")
         NetworkService.shared.bookmarkService.postBookmarkState(myAccountId: 1, markedAccountId: markedButtonId) { result in
             switch result {
             case 200:
@@ -195,6 +204,7 @@ private extension TransferViewController {
     }
     
     func deleteBookmarkState(markedButtonId: Int, cell: RecentTransferCell) {
+        print("deleteBookmarkState - 요청 데이터: myAccountId: 1, markedAccountId: \(markedButtonId)")
         NetworkService.shared.transferService.deleteBookmarkState(myAccountId: 1, markedAccountId: markedButtonId) { result in
             switch result {
             case 200:
@@ -286,6 +296,8 @@ extension TransferViewController: UICollectionViewDataSource {
             cell.isFavorite = transferData.isAccountLike
             cell.markedButtonId = transferData.accountID
             cell.delegate = self
+            
+            print("cellForItemAt - 셀 설정 완료: \(transferData.accountName), isFavorite: \(transferData.isAccountLike)")
             
             return cell
         }

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/ViewControllers/TransferViewController.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/Transfer/ViewControllers/TransferViewController.swift
@@ -186,8 +186,23 @@ private extension TransferViewController {
             switch result {
             case 200:
                 cell.isFavorite = !cell.isFavorite
+                print("즐겨찾기 추가 성공: \(markedButtonId)")
             default:
-                print("에러입니다")
+                print("즐겨찾기 추가 에러입니다")
+            }
+        }
+    }
+    
+    func deleteBookmarkState(markedButtonId: Int, cell: RecentTransferCell) {
+        NetworkService.shared.transferService.deleteBookmarkState(myAccountId: 1, markedAccountId: markedButtonId) { result in
+            switch result {
+            case 200:
+                cell.isFavorite = !cell.isFavorite
+                print("즐겨찾기 삭제 성공: \(markedButtonId)")
+            case 500:
+                print("서버 오류입니다. 나중에 다시 시도해주세요.")
+            default:
+                print("즐겨찾기 삭제 에러: \(result)")
             }
         }
     }
@@ -221,7 +236,7 @@ extension TransferViewController: RecentTransferDelegate {
         if !cell.isFavorite {
             self.postBookmarkState(markedButtonId: markedButtonId, cell: cell)
         } else {
-            // 즐겨찾기 해제 서버 통신
+            self.deleteBookmarkState(markedButtonId: markedButtonId, cell: cell)
         }
     }
     
@@ -264,10 +279,13 @@ extension TransferViewController: UICollectionViewDataSource {
             
         case .recentTransfer:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RecentTransferCell.cellIdentifier, for: indexPath) as? RecentTransferCell else { return UICollectionViewCell() }
-            cell.accountInfoView.bindAccountInfo(data: recentTransferData[indexPath.row])
-            cell.isFavorite = recentTransferData[indexPath.row].isAccountLike
-            cell.markedButtonId = recentTransferData[indexPath.row].accountID
+            
+            let transferData = recentTransferData[indexPath.row]
+            cell.accountInfoView.bindAccountInfo(data: transferData)
+            cell.isFavorite = transferData.isAccountLike
+            cell.markedButtonId = transferData.accountID
             cell.delegate = self
+            
             return cell
         }
     }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- feature/#49

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 메인 페이지의 GET 메인 통장 정보
- 이체 화면에서 DELETE 즐겨찾기

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 스크린샷에서 보면 되는 건 첫 메인 화면에서 계좌 세 개의 이름과 잔액이 바뀌어 있는 것과 이체화면에서 즐겨찾기 해제 잘 되는 것 보시면 됩니다!
- 메인 페이지의 Network는 MainAccount 폴더 보시면 됩니다.
- 이체 화면의 Delete는 Transfer 폴더에 코드 추가하여 사용했습니다.
- MainPage 폴더의 Views에 MainAccountView, SecondAccountView, ThirdAccountView에는 마지막에 API를 화면에 반영하는 코드를 추가했습니다.
```
func configure(with response: GetMainAccountResponse) {
         titleLabel.text = response.accountName
         balanceLabel.text = "\(response.balance)원"
     }
```

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰15Pro|<img src="https://github.com/NOW-SOPT-APP2-KAKAOBANK/KAKAOBANK-iOS/assets/96602351/f3edfb73-d618-49dd-b77e-c891bc897b18" width="300">|

## 📟 관련 이슈
- Resolved: #49
