### PR TITLE
[FIX] 뷰 디테일 수정 (#59)

### DIFF
--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/MonthlyPayment/DTO/GetPaymentResponse.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/MonthlyPayment/DTO/GetPaymentResponse.swift
@@ -27,6 +27,7 @@ extension MonthlyTransferList {
             dateLabel: self.date,
             transactionLabel: self.accountName,
             tagLabel: self.hashTag ?? "",
+            isWithdraw: self.isWithdraw,
             transactionAmountLabel: "\(self.transferAmount)원",
             totalAmountLabel: "\(self.balance)원"
         )

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/MonthlyPayment/DTO/GetPaymentResponse.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/MonthlyPayment/DTO/GetPaymentResponse.swift
@@ -17,7 +17,6 @@ struct MonthlyTransferList: Codable {
     let date: String
     let transferAmount: Int
     let balance: Int
-    let isWithdraw: Bool
     let hashTag: String?
 }
 
@@ -27,7 +26,6 @@ extension MonthlyTransferList {
             dateLabel: self.date,
             transactionLabel: self.accountName,
             tagLabel: self.hashTag ?? "",
-            isWithdraw: self.isWithdraw,
             transactionAmountLabel: "\(self.transferAmount)원",
             totalAmountLabel: "\(self.balance)원"
         )

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/MonthlyPayment/DTO/GetPaymentResponse.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/MonthlyPayment/DTO/GetPaymentResponse.swift
@@ -31,3 +31,4 @@ extension MonthlyTransferList {
         )
     }
 }
+

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/Cells/BankAccountTableViewCell.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/Cells/BankAccountTableViewCell.swift
@@ -114,7 +114,7 @@ extension BankAccountTableViewCell {
         tagLabel.text = data.tagLabel
         transactionAmountLabel.text = data.transactionAmountLabel
         totalAmountLabel.text = data.totalAmountLabel
-
+        
         if let firstChar = data.transactionAmountLabel.first {
             setTextColor(for: firstChar)
         }
@@ -122,8 +122,9 @@ extension BankAccountTableViewCell {
     
     private func setTextColor(for firstCharacter: Character) {
         if firstCharacter == "-" {
-            transactionAmountLabel.textColor = UIColor(resource: .black2)
+            transactionAmountLabel.textColor = UIColor(resource: .black2) 
+        } else {
+            transactionAmountLabel.textColor = UIColor(resource: .deepblue0)
         }
     }
 }
-

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/Cells/BankAccountTableViewCell.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/Cells/BankAccountTableViewCell.swift
@@ -111,15 +111,17 @@ extension BankAccountTableViewCell {
     func dataBind(_ data: BankAccountModel) {
         dateLabel.text = data.dateLabel
         transactionLabel.text = data.transactionLabel
-        tagLabel.text = data.tagLabel
         transactionAmountLabel.text = data.transactionAmountLabel
         totalAmountLabel.text = data.totalAmountLabel
-        
+
+        //해시태그가 공백일때와 아닐때 # 처리
+        tagLabel.text = data.tagLabel != "" ? "#\(data.tagLabel)" : data.tagLabel
+
         if let firstChar = data.transactionAmountLabel.first {
             setTextColor(for: firstChar)
         }
     }
-    
+
     private func setTextColor(for firstCharacter: Character) {
         if firstCharacter == "-" {
             transactionAmountLabel.textColor = UIColor(resource: .black2) 

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/Models/BankAccountModel.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/Models/BankAccountModel.swift
@@ -11,13 +11,12 @@ struct BankAccountModel {
     let dateLabel: String
     let transactionLabel: String
     let tagLabel: String
-    let isWithdraw :Bool
     let transactionAmountLabel: String
     let totalAmountLabel: String
 }
 
 extension BankAccountModel {
     static let transactionData:[BankAccountModel] = [
-        BankAccountModel(dateLabel: "05.21", transactionLabel: "ㅎㅎㅎ", tagLabel: "#키득키득",isWithdraw: true, transactionAmountLabel: "0원", totalAmountLabel: "0원")]
+        BankAccountModel(dateLabel: "05.21", transactionLabel: "ㅎㅎㅎ", tagLabel: "#키득키득", transactionAmountLabel: "0원", totalAmountLabel: "0원")]
 }
 

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/Models/BankAccountModel.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/Models/BankAccountModel.swift
@@ -11,12 +11,13 @@ struct BankAccountModel {
     let dateLabel: String
     let transactionLabel: String
     let tagLabel: String
+    let isWithdraw :Bool
     let transactionAmountLabel: String
     let totalAmountLabel: String
 }
 
 extension BankAccountModel {
     static let transactionData:[BankAccountModel] = [
-        BankAccountModel(dateLabel: "05.21", transactionLabel: "ㅎㅎㅎ", tagLabel: "#키득키득", transactionAmountLabel: "0원", totalAmountLabel: "0원")]
+        BankAccountModel(dateLabel: "05.21", transactionLabel: "ㅎㅎㅎ", tagLabel: "#키득키득",isWithdraw: true, transactionAmountLabel: "0원", totalAmountLabel: "0원")]
 }
 

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/ViewControllers/BankAccountViewController.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/ViewControllers/BankAccountViewController.swift
@@ -83,8 +83,6 @@ private extension BankAccountViewController {
                 self.bankAccountList = data.monthlyTransferList.map { $0.toBankAccountModel() }
                 self.bankAccountTableView.reloadData()
 
-
-
                 DispatchQueue.main.async {
                     let contentHeight = CGFloat(self.bankAccountList.count) * 87
                     self.bankAccountTableView.snp.remakeConstraints {
@@ -110,13 +108,16 @@ private extension BankAccountViewController {
         }
     }
     
-    func setMonth(){
+    func setMonth() {
         self.stickyHeaderView.dateLabel.text = "2024 \(currentMonth)월"
         self.stickyHeaderView.monthlyTotalLabel.text = "\(currentMonth)월 전체"
         self.headerView.dateLabel.text = "2024 \(currentMonth)월"
         self.headerView.monthlyTotalLabel.text = "\(currentMonth)월 전체"
     }
-    
+    // 거래금액 색상
+    func setTransferAmountColor() {
+        
+    }
     func formatAccount(_ accountNumber: String) -> String {
         var formattedAccount = ""
         for (index, char) in accountNumber.enumerated() {

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/ViewControllers/BankAccountViewController.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/ViewControllers/BankAccountViewController.swift
@@ -114,10 +114,7 @@ private extension BankAccountViewController {
         self.headerView.dateLabel.text = "2024 \(currentMonth)월"
         self.headerView.monthlyTotalLabel.text = "\(currentMonth)월 전체"
     }
-    // 거래금액 색상
-    func setTransferAmountColor() {
-        
-    }
+  
     func formatAccount(_ accountNumber: String) -> String {
         var formattedAccount = ""
         for (index, char) in accountNumber.enumerated() {


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- fix/#59

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
 입금 시 텍스트가 파란색으로 보이도록 하는 로직 수정했습니다
 해시태그 nil일때 처리 "#"가 붙지 않도록 하는 메서드 추가했어요

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
```
private func setTextColor(for firstCharacter: Character) {
        if firstCharacter == "-" {
            transactionAmountLabel.textColor = UIColor(resource: .black2) 
        } else {
            transactionAmountLabel.textColor = UIColor(resource: .deepblue0)
        }
    }
```
```
//해시태그가 공백일때와 아닐때 # 처리
tagLabel.text = data.tagLabel != "" ? "#\(data.tagLabel)" : data.tagLabel
```

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰15Pro|![Simulator Screen Recording - iPhone 15 Pro - 2024-05-23 at 17 10 42](https://github.com/NOW-SOPT-APP2-KAKAOBANK/KAKAOBANK-iOS/assets/105372558/38ecad9f-3258-48ef-ab88-00fe006ec014)|



## 📟 관련 이슈
- Resolved: #59 
