### PR TITLE
[ADD] 숫자 사이에 , 추가 (#65)

### DIFF
--- a/KAKAOBANK-iOS/KAKAOBANK-iOS.xcodeproj/project.pbxproj
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0D3F13562BFDB38B00B2685E /* MyAccountService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D3F13552BFDB38B00B2685E /* MyAccountService.swift */; };
 		0D3F13582BFDB3E500B2685E /* MyAccountTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D3F13572BFDB3E500B2685E /* MyAccountTargetType.swift */; };
 		0D3F135C2BFDB8DF00B2685E /* GetMyAccountResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D3F135B2BFDB8DF00B2685E /* GetMyAccountResponse.swift */; };
+		0D5065212C00155200FA3E7C /* IntFormat+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5065202C00155200FA3E7C /* IntFormat+.swift */; };
 		0D5AB9052BF2663C00C41046 /* BankAccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5AB9042BF2663C00C41046 /* BankAccountViewController.swift */; };
 		0D5AB9072BF267E700C41046 /* BankAccountNaviBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5AB9062BF267E700C41046 /* BankAccountNaviBar.swift */; };
 		0DB63ACA2BF7565D007AA8C8 /* BankAccountUpperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB63AC92BF7565D007AA8C8 /* BankAccountUpperView.swift */; };
@@ -93,6 +94,7 @@
 		0D3F13552BFDB38B00B2685E /* MyAccountService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAccountService.swift; sourceTree = "<group>"; };
 		0D3F13572BFDB3E500B2685E /* MyAccountTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAccountTargetType.swift; sourceTree = "<group>"; };
 		0D3F135B2BFDB8DF00B2685E /* GetMyAccountResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetMyAccountResponse.swift; sourceTree = "<group>"; };
+		0D5065202C00155200FA3E7C /* IntFormat+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IntFormat+.swift"; sourceTree = "<group>"; };
 		0D5AB9042BF2663C00C41046 /* BankAccountViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankAccountViewController.swift; sourceTree = "<group>"; };
 		0D5AB9062BF267E700C41046 /* BankAccountNaviBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankAccountNaviBar.swift; sourceTree = "<group>"; };
 		0DB63AC92BF7565D007AA8C8 /* BankAccountUpperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankAccountUpperView.swift; sourceTree = "<group>"; };
@@ -473,6 +475,7 @@
 				CA22B3FC2BF147040013B7AB /* UIStackView+.swift */,
 				CA22B3FE2BF147980013B7AB /* UICollectionViewCell+.swift */,
 				CA22B4002BF147BF0013B7AB /* UITableViewCell.swift */,
+				0D5065202C00155200FA3E7C /* IntFormat+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -712,6 +715,7 @@
 				CA0C2CDA2BFC7DCD0026C6C7 /* MoyaLoggingPlugin.swift in Sources */,
 				0D5AB9072BF267E700C41046 /* BankAccountNaviBar.swift in Sources */,
 				2C28353B2BF523A000245FE1 /* AddButtonView.swift in Sources */,
+				0D5065212C00155200FA3E7C /* IntFormat+.swift in Sources */,
 				2CD3F19B2BFE247C00596073 /* GetMainAccountResponse.swift in Sources */,
 				CA22B3F92BF13C380013B7AB /* UILabel+.swift in Sources */,
 				CA05B3A32BF27AF300DA77E1 /* MyAccountCell.swift in Sources */,

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Global/Extension/IntFormat+.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Global/Extension/IntFormat+.swift
@@ -1,0 +1,17 @@
+//
+//  IntFormat+.swift
+//  KAKAOBANK-iOS
+//
+//  Created by 김민서 on 5/24/24.
+//
+
+import Foundation
+
+extension Int {
+    var formattedWithSeparator: String {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        return numberFormatter.string(from: NSNumber(value: self)) ?? ""
+    }
+}
+

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/MonthlyPayment/DTO/GetPaymentResponse.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Network/MonthlyPayment/DTO/GetPaymentResponse.swift
@@ -26,8 +26,8 @@ extension MonthlyTransferList {
             dateLabel: self.date,
             transactionLabel: self.accountName,
             tagLabel: self.hashTag ?? "",
-            transactionAmountLabel: "\(self.transferAmount)원",
-            totalAmountLabel: "\(self.balance)원"
+            transactionAmountLabel: "\(self.transferAmount.formattedWithSeparator)원",
+            totalAmountLabel: "\(self.balance.formattedWithSeparator)원"
         )
     }
 }

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/ViewControllers/BankAccountViewController.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/ViewControllers/BankAccountViewController.swift
@@ -53,11 +53,9 @@ private extension BankAccountViewController {
         NetworkService.shared.myAccountService.getMyAccount(accountId: 1) { result in
             switch result {
             case .success(let data):
-                let formattedAccount = self.formatAccount("\(data.accountNumber)")
-                
                 self.bankAccountNaviBar.titleLabel.text = data.accountName
-                self.bankAccountUpperView.balanceLabel.text = "\(data.balance)"
-                self.bankAccountUpperView.accountLabel.text = formattedAccount
+                self.bankAccountUpperView.balanceLabel.text = "\(data.balance.formattedWithSeparator)"
+                self.bankAccountUpperView.accountLabel.text = self.formatAccount("\(data.accountNumber)")
                 self.setMonth()
                 
             case .requestErr:
@@ -78,8 +76,8 @@ private extension BankAccountViewController {
         NetworkService.shared.paymentService.getPayment(accountId: 1, month: currentMonth) { result in
             switch result {
             case .success(let data):
-                self.stickyHeaderView.totalAmountLabel.text = "\(data.payment)원"
-                self.headerView.totalAmountLabel.text = "\(data.payment)원"
+                self.stickyHeaderView.totalAmountLabel.text = "\(data.payment.formattedWithSeparator)원"
+                self.headerView.totalAmountLabel.text = "\(data.payment.formattedWithSeparator)원"
                 self.bankAccountList = data.monthlyTransferList.map { $0.toBankAccountModel() }
                 self.bankAccountTableView.reloadData()
 
@@ -108,12 +106,24 @@ private extension BankAccountViewController {
         }
     }
     
+    
     func setMonth() {
         self.stickyHeaderView.dateLabel.text = "2024 \(currentMonth)월"
         self.stickyHeaderView.monthlyTotalLabel.text = "\(currentMonth)월 전체"
         self.headerView.dateLabel.text = "2024 \(currentMonth)월"
         self.headerView.monthlyTotalLabel.text = "\(currentMonth)월 전체"
     }
+    
+//    func formatNumber(_ accountNumber: Int) -> String {
+//        let requestNumber: Int = accountNumber
+//
+//        let numberFormatter: NumberFormatter = NumberFormatter()
+//        numberFormatter.numberStyle = .decimal
+//        
+//        let fotmattedNumber: String = numberFormatter.string(for: requestNumber)!
+//        
+//        return fotmattedNumber
+//    }
   
     func formatAccount(_ accountNumber: String) -> String {
         var formattedAccount = ""

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/ViewControllers/BankAccountViewController.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/ViewControllers/BankAccountViewController.swift
@@ -48,83 +48,6 @@ final class BankAccountViewController: UIViewController {
 }
 
 private extension BankAccountViewController {
-    
-    func getMyAccount() {
-        NetworkService.shared.myAccountService.getMyAccount(accountId: 1) { result in
-            switch result {
-            case .success(let data):
-                self.bankAccountNaviBar.titleLabel.text = data.accountName
-                self.bankAccountUpperView.balanceLabel.text = "\(data.balance.formattedWithSeparator)"
-                self.bankAccountUpperView.accountLabel.text = self.formatAccount("\(data.accountNumber)")
-                self.setMonth()
-                
-            case .requestErr:
-                print("요청 오류입니다")
-            case .decodedErr:
-                print("디코딩 오류입니다")
-            case .pathErr:
-                print("경로 오류입니다")
-            case .serverErr:
-                print("서버 오류입니다")
-            case .networkFail:
-                print("네트워크 오류입니다")
-            }
-        }
-    }
-    
-    func getPayment() {
-        NetworkService.shared.paymentService.getPayment(accountId: 1, month: currentMonth) { result in
-            switch result {
-            case .success(let data):
-                self.stickyHeaderView.totalAmountLabel.text = "\(data.payment.formattedWithSeparator)원"
-                self.headerView.totalAmountLabel.text = "\(data.payment.formattedWithSeparator)원"
-                self.bankAccountList = data.monthlyTransferList.map { $0.toBankAccountModel() }
-                self.bankAccountTableView.reloadData()
-
-                DispatchQueue.main.async {
-                    let contentHeight = CGFloat(self.bankAccountList.count) * 87
-                    self.bankAccountTableView.snp.remakeConstraints {
-                        $0.top.equalTo(self.stickyHeaderView.snp.bottom)
-                        $0.leading.trailing.equalToSuperview()
-                        $0.height.equalTo(contentHeight)
-                        $0.bottom.equalTo(self.contentView)
-                    }
-                    self.view.layoutIfNeeded()
-                }
-                
-            case .requestErr:
-                print("요청 오류입니다")
-            case .decodedErr:
-                print("디코딩 오류입니다")
-            case .pathErr:
-                print("경로 오류입니다")
-            case .serverErr:
-                print("서버 오류입니다")
-            case .networkFail:
-                print("네트워크 오류입니다")
-            }
-        }
-    }
-    
-    
-    func setMonth() {
-        self.stickyHeaderView.dateLabel.text = "2024 \(currentMonth)월"
-        self.stickyHeaderView.monthlyTotalLabel.text = "\(currentMonth)월 전체"
-        self.headerView.dateLabel.text = "2024 \(currentMonth)월"
-        self.headerView.monthlyTotalLabel.text = "\(currentMonth)월 전체"
-    }
-  
-    func formatAccount(_ accountNumber: String) -> String {
-        var formattedAccount = ""
-        for (index, char) in accountNumber.enumerated() {
-            if index == 4 || index == 6 {
-                formattedAccount.append("-")
-            }
-            formattedAccount.append(char)
-        }
-        return formattedAccount
-    }
-    
     func setHierarchy() {
         self.view.addSubviews(backgroundView, scrollView, bankAccountNaviBar, headerView)
         
@@ -227,6 +150,84 @@ private extension BankAccountViewController {
         }
     }
     
+}
+
+private extension BankAccountViewController {
+    func getMyAccount() {
+        NetworkService.shared.myAccountService.getMyAccount(accountId: 1) { result in
+            switch result {
+            case .success(let data):
+                self.bankAccountNaviBar.titleLabel.text = data.accountName
+                self.bankAccountUpperView.balanceLabel.text = "\(data.balance.formattedWithSeparator)"
+                self.bankAccountUpperView.accountLabel.text = self.formatAccount("\(data.accountNumber)")
+                self.setMonth()
+                
+            case .requestErr:
+                print("요청 오류입니다")
+            case .decodedErr:
+                print("디코딩 오류입니다")
+            case .pathErr:
+                print("경로 오류입니다")
+            case .serverErr:
+                print("서버 오류입니다")
+            case .networkFail:
+                print("네트워크 오류입니다")
+            }
+        }
+    }
+    
+    func getPayment() {
+        NetworkService.shared.paymentService.getPayment(accountId: 1, month: currentMonth) { result in
+            switch result {
+            case .success(let data):
+                self.stickyHeaderView.totalAmountLabel.text = "\(data.payment.formattedWithSeparator)원"
+                self.headerView.totalAmountLabel.text = "\(data.payment.formattedWithSeparator)원"
+                self.bankAccountList = data.monthlyTransferList.map { $0.toBankAccountModel() }
+                self.bankAccountTableView.reloadData()
+                
+                DispatchQueue.main.async {
+                    let contentHeight = CGFloat(self.bankAccountList.count) * 87
+                    self.bankAccountTableView.snp.remakeConstraints {
+                        $0.top.equalTo(self.stickyHeaderView.snp.bottom)
+                        $0.leading.trailing.equalToSuperview()
+                        $0.height.equalTo(contentHeight)
+                        $0.bottom.equalTo(self.contentView)
+                    }
+                    self.view.layoutIfNeeded()
+                }
+                
+            case .requestErr:
+                print("요청 오류입니다")
+            case .decodedErr:
+                print("디코딩 오류입니다")
+            case .pathErr:
+                print("경로 오류입니다")
+            case .serverErr:
+                print("서버 오류입니다")
+            case .networkFail:
+                print("네트워크 오류입니다")
+            }
+        }
+    }
+    
+    
+    func setMonth() {
+        self.stickyHeaderView.dateLabel.text = "2024 \(currentMonth)월"
+        self.stickyHeaderView.monthlyTotalLabel.text = "\(currentMonth)월 전체"
+        self.headerView.dateLabel.text = "2024 \(currentMonth)월"
+        self.headerView.monthlyTotalLabel.text = "\(currentMonth)월 전체"
+    }
+    
+    func formatAccount(_ accountNumber: String) -> String {
+        var formattedAccount = ""
+        for (index, char) in accountNumber.enumerated() {
+            if index == 4 || index == 6 {
+                formattedAccount.append("-")
+            }
+            formattedAccount.append(char)
+        }
+        return formattedAccount
+    }
 }
 
 extension BankAccountViewController: UITableViewDataSource, UITableViewDelegate {

--- a/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/ViewControllers/BankAccountViewController.swift
+++ b/KAKAOBANK-iOS/KAKAOBANK-iOS/Presentation/BankAccount/ViewControllers/BankAccountViewController.swift
@@ -113,17 +113,6 @@ private extension BankAccountViewController {
         self.headerView.dateLabel.text = "2024 \(currentMonth)월"
         self.headerView.monthlyTotalLabel.text = "\(currentMonth)월 전체"
     }
-    
-//    func formatNumber(_ accountNumber: Int) -> String {
-//        let requestNumber: Int = accountNumber
-//
-//        let numberFormatter: NumberFormatter = NumberFormatter()
-//        numberFormatter.numberStyle = .decimal
-//        
-//        let fotmattedNumber: String = numberFormatter.string(for: requestNumber)!
-//        
-//        return fotmattedNumber
-//    }
   
     func formatAccount(_ accountNumber: String) -> String {
         var formattedAccount = ""


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- add/#65 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
정수 3자리 마다 콤마를 넣는 기능을 추가했습니다! 

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
IntFormat+ extension을 추가했습니다!
정수형 타입 뒤에 `.formattedWithSeparator`을 붙여 사용하면 됩니다!
```
self.bankAccountUpperView.balanceLabel.text = "\(data.balance.formattedWithSeparator)"
```

```
import Foundation

extension Int {
    var formattedWithSeparator: String {
        let numberFormatter = NumberFormatter()
        numberFormatter.numberStyle = .decimal
        return numberFormatter.string(from: NSNumber(value: self)) ?? ""
    }
}
```


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰15Pro|![Simulator Screenshot - iPhone 15 Pro - 2024-05-24 at 09 49 18](https://github.com/NOW-SOPT-APP2-KAKAOBANK/KAKAOBANK-iOS/assets/105372558/8ba53f5b-15cf-4055-a725-b951e7d12a69)
|



## 📟 관련 이슈
- Resolved: #65 
